### PR TITLE
Fixed minor typos in modules and flake8 typo

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,9 +2,11 @@
 max-line-length = 88
 extend-ignore =
 	E203,
-	D1,  # Uncomment to disable enforcing docstrings 
+	# Uncomment to disable enforcing docstrings
+	D1,
 required-plugins =
 	flake8-docstring,
 docstring-convention = google
 per-file-ignores =
-     tests/*:D100,D104  # Uncomment to disable enforcing module-level docstring in tests/
+    # Uncomment to disable enforcing module-level docstring in tests/
+     tests/*:D100,D104

--- a/.flake8
+++ b/.flake8
@@ -9,4 +9,5 @@ required-plugins =
 docstring-convention = google
 per-file-ignores =
     # Uncomment to disable enforcing module-level docstring in tests/
-     tests/*:D100,D104
+     tests/*:D100,D104,
+	 __init__.py:F401

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Work in progress.
 
 ## Using batteryDAT
 
-
 ## Installing batteryDAT
 
 ## Citing batteryDAT

--- a/batteryDAT/__init__.py
+++ b/batteryDAT/__init__.py
@@ -1,4 +1,4 @@
 """The main module for MyProject."""
 from cell_data import BatteryCell
 
-__version__ = "0.1.0"
+__version__ = "0.0.1"

--- a/batteryDAT/__init__.py
+++ b/batteryDAT/__init__.py
@@ -1,4 +1,4 @@
 """The main module for MyProject."""
-from cell_data import BatteryCell
+from batteryDAT.cell_data import BatteryCell
 
 __version__ = "0.0.1"

--- a/batteryDAT/analysis_functions.py
+++ b/batteryDAT/analysis_functions.py
@@ -13,7 +13,8 @@ Contains various functions for analysing battery data, including:
 
 import numpy as np
 import pandas as pd
-from constants import (
+
+from batteryDAT.constants import (
     CURRENT,
     DIFF_CAPACITY,
     DIFF_RESISTANCE,

--- a/batteryDAT/cell_data.py
+++ b/batteryDAT/cell_data.py
@@ -2,11 +2,12 @@
 # -*- coding: utf-8 -*-
 """cell_data module for defining the BatteryCell class and its methods."""
 
-import analysis_functions as af
-import dma_functions as dma
 import pandas as pd
-import parsers
-from constants import CURRENT, DIS_CHARGE, OHM_RESISTANCE, SOC, TIME, VOLTAGE
+
+import batteryDAT.analysis_functions as af
+import batteryDAT.dma_functions as dma
+import batteryDAT.parsers as parsers
+from batteryDAT.constants import CURRENT, DIS_CHARGE, OHM_RESISTANCE, SOC, TIME, VOLTAGE
 
 
 class BatteryCell:

--- a/batteryDAT/cell_data.py
+++ b/batteryDAT/cell_data.py
@@ -1,6 +1,6 @@
 # mypy: ignore-errors
 # -*- coding: utf-8 -*-
-"""Battery_data module for defining the BatteryCell class and its methods."""
+"""cell_data module for defining the BatteryCell class and its methods."""
 
 import analysis_functions as af
 import dma_functions as dma
@@ -315,7 +315,7 @@ class BatteryCell:
         return battery_data
 
     def add_data(self, filename, **kwargs):
-        """Add additional data to the raw_data dicitonary.
+        """Add additional data to the raw_data dictionary.
 
         add_data acts in a similar way as the load_data method, but without
         creating a new BatteryCell object and without the option of assigning

--- a/batteryDAT/dma_functions.py
+++ b/batteryDAT/dma_functions.py
@@ -4,8 +4,9 @@
 
 import numpy as np
 import pandas as pd
-from constants import CURRENT, DIS_CHARGE, OCV, SOC, VOLTAGE
 from scipy import optimize
+
+from batteryDAT.constants import CURRENT, DIS_CHARGE, OCV, SOC, VOLTAGE
 
 # --------- electrode-level calculations ---------
 

--- a/batteryDAT/parsers.py
+++ b/batteryDAT/parsers.py
@@ -10,7 +10,16 @@ files) into pandas dataframe objects.
 
 import numpy as np
 import pandas as pd
-from constants import CURRENT, DIS_CHARGE, NET_CHARGE, NS, TEMPERATURE, TIME, VOLTAGE
+
+from batteryDAT.constants import (
+    CURRENT,
+    DIS_CHARGE,
+    NET_CHARGE,
+    NS,
+    TEMPERATURE,
+    TIME,
+    VOLTAGE,
+)
 
 names_dictionary = {
     "time/s": TIME,

--- a/tests/test_batteryDAT.py
+++ b/tests/test_batteryDAT.py
@@ -4,4 +4,4 @@ from batteryDAT import __version__
 
 def test_version():
     """Check that the version is acceptable."""
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.0.1"


### PR DESCRIPTION
# Description

- Removed inline comments in flake8 which were causing issues.
- Added __init__.py to ignore list in flake8 for importing unused modules.
- Fixed typo with version number in __init__.py and test_batteryDAT.py.
- Fixed two typos in dosctrings in cell_data.py.
- Removed blank line from README.md
- Added batteryDAT to import statements for batteryDAT modules.

Fixes # (issue)

## Type of change

- [x] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
